### PR TITLE
feat: update maven-shade dependency to version 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.3.0-SNAPSHOT</version>
+        <version>3.6.0</version>
         <configuration>
           <filters>
             <filter>


### PR DESCRIPTION
**Changes**
- Bump version of `maven-shade` to 3.6.0